### PR TITLE
fix: 統一プロパティ名 current_price → current_highest_bid

### DIFF
--- a/src/app/api/bids/route.ts
+++ b/src/app/api/bids/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
     
     // 最低入札額チェック
     const bidAmount = Number(amount)
-    const currentMaxBid = auction.current_price || auction.starting_price
+    const currentMaxBid = auction.current_highest_bid || auction.starting_price
     
     if (bidAmount <= currentMaxBid) {
       return NextResponse.json(
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
     await supabase
       .from('auctions')
       .update({ 
-        current_price: bidAmount,
+        current_highest_bid: bidAmount,
         updated_at: new Date().toISOString()
       })
       .eq('id', auction_id)

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -142,7 +142,7 @@ async function handlePaymentIntentFailed(
       await supabase
         .from('auctions')
         .update({
-          current_price: highestBid.amount,
+          current_highest_bid: highestBid.amount,
           updated_at: new Date().toISOString()
         })
         .eq('id', auction_id)
@@ -158,7 +158,7 @@ async function handlePaymentIntentFailed(
         await supabase
           .from('auctions')
           .update({
-            current_price: auction.starting_price,
+            current_highest_bid: auction.starting_price,
             updated_at: new Date().toISOString()
           })
           .eq('id', auction_id)

--- a/src/app/widget/page.tsx
+++ b/src/app/widget/page.tsx
@@ -184,7 +184,7 @@ export default function WidgetPage() {
     const amount = parseInt(bidAmount)
     
     // 入札額のバリデーション
-    if (isNaN(amount) || amount < auction.current_price + 1000) {
+    if (isNaN(amount) || amount < auction.current_highest_bid + 1000) {
       setError('入札額は現在価格より1,000円以上高く設定してください')
       return
     }


### PR DESCRIPTION
## 概要

Auctionタイプで`current_price`と`current_highest_bid`の2つの異なるプロパティ名が混在していた問題を修正しました。

TypeScript型定義に合わせて、すべてのファイルで`current_highest_bid`を使用するよう統一しました。

## 変更内容

- `src/app/widget/page.tsx`: 入札額バリデーションで`current_highest_bid`を使用
- `src/app/api/bids/route.ts`: 最低入札額チェックとDB更新で`current_highest_bid`を使用
- `src/app/api/webhooks/stripe/route.ts`: 決済失敗時の価格更新で`current_highest_bid`を使用

Closes #12

Generated with [Claude Code](https://claude.ai/code)