### PR TITLE
fix: 認証セッションモジュールの実装

### DIFF
--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,47 @@
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
+
+export interface Session {
+  user: {
+    id: string;
+    email: string;
+    name?: string;
+  };
+}
+
+export async function getServerSession(): Promise<Session | null> {
+  try {
+    const cookieStore = await cookies();
+    const supabase = createClient(cookieStore);
+    
+    const { data: { user }, error } = await supabase.auth.getUser();
+    
+    if (error || !user) {
+      return null;
+    }
+    
+    // ユーザープロファイルから名前を取得
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('display_name, username')
+      .eq('id', user.id)
+      .single();
+    
+    // 名前の優先順位: display_name > username > user_metadata.username > emailの@前
+    const name = profile?.display_name || 
+                 profile?.username || 
+                 user.user_metadata?.username ||
+                 user.email?.split('@')[0];
+    
+    return {
+      user: {
+        id: user.id,
+        email: user.email || '',
+        name: name || undefined,
+      }
+    };
+  } catch (error) {
+    console.error('getServerSession error:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要
`src/app/api/checkout/route.ts`から参照されている`@/lib/auth/session`モジュールを実装しました。

## 変更内容
- `getServerSession()`関数のSupabaseサーバーサイド認証実装
- TypeScript型定義の完備
- プロファイル名の取得ロジック実装

Fixes #10

Generated with [Claude Code](https://claude.ai/code)